### PR TITLE
feat:자동로그인,로그아웃 #16

### DIFF
--- a/src/main/java/org/shds/smartpay/config/SecurityConfig.java
+++ b/src/main/java/org/shds/smartpay/config/SecurityConfig.java
@@ -57,7 +57,7 @@ public class SecurityConfig {
             auth.requestMatchers("/","/index.html","/css/**", "/images/**", "/js/**", "/favicon.ico", "/h2-console/**").permitAll()
                     .requestMatchers("/member/signup", "/oauth2/sign-up", "/login","/logout", "/api/payment/done").permitAll() // 특정 페이지 접근 허용
                     //.anyRequest().authenticated(); // 위의 경로 이외에는 모두 인증된 사용자만 접근 가능
-                    .requestMatchers("/member/jwt-test","/member/tetest").hasRole("USER")
+                    .requestMatchers("/member/jwt-test","/member/tetest","/member/logout").hasRole("USER")
                     .anyRequest().permitAll();
                     //.anyRequest().authenticated();
 

--- a/src/main/java/org/shds/smartpay/entity/Member.java
+++ b/src/main/java/org/shds/smartpay/entity/Member.java
@@ -53,4 +53,9 @@ public class Member extends BaseEntity{
         this.refreshToken = updateRefreshToken;
     }
 
+    // 리프레시 토큰을 초기화하는 메소드
+    public void initRefreshToken() {
+        this.refreshToken = null;  // 리프레시 토큰을 null로 설정
+    }
+
 }

--- a/src/main/java/org/shds/smartpay/filter/CORSFilter.java
+++ b/src/main/java/org/shds/smartpay/filter/CORSFilter.java
@@ -4,6 +4,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -12,6 +13,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+@Slf4j
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class CORSFilter extends OncePerRequestFilter {
@@ -21,8 +23,10 @@ public class CORSFilter extends OncePerRequestFilter {
         response.setHeader("Access-Control-Allow-Credentials","true");
         response.setHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS, DELETE");
         response.setHeader("Access-Control-Max-Age", "3600");
-        response.setHeader("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept, Key , Authorization");
-        response.setHeader("Access-Control-Expose-Headers", "Authorization, Authorization-refresh");
+        response.setHeader("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept, Key, Authorization, Authorization-refresh");
+        response.setHeader("Access-Control-Expose-Headers", "Authorization, Authorization-refresh, Set-Cookie");
+        log.info("CORS Filter 들어와지나요? ");
+        System.out.println("CORS Filter 들어와지나요? ");
         if("OPTIONS".equals(request.getMethod())) {
             response.setStatus(HttpServletResponse.SC_OK);
         }else{


### PR DESCRIPTION
- 한번로그인해서 쿠키에 리프레시 토큰 저장된 상태로는 브라우저 껏다켜도 로그인 프로바이더가 적용된 페이지에 직접 접근시도하면 다시 로그인 안해도 쿠키에서 리프레시토큰 가지고 다시 액세스토큰 가져온뒤에 통신
- 헤더에 달린 로그아웃 버튼 누르면 백엔드로 보내서 쿠키의 리프레시 토큰 삭제하고, DB에서도 리프레시 토큰  삭제함 -> 추후 redis에 TTL 달고 쓰면 더 좋을듯 